### PR TITLE
Update 18.6 to use 2 spaces instead of 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1639,7 +1639,7 @@ ESLint rules (applies this guide as linting rules):
   ```
 
   - [18.6](#18.6) <a name='18.6'></a> Use indentation when making long method chains. Use a leading dot, which
-    emphasizes that the line is a method call, not a new statement.  Chaining should use a 4 character continuation indent
+    emphasizes that the line is a method call, not a new statement.  Chaining should use a 2 character continuation indent
 
   ```javascript
   // bad
@@ -1655,11 +1655,11 @@ ESLint rules (applies this guide as linting rules):
 
   // good
   $('#items')
-      .find('.selected')
-      .highlight()
-      .end()
-      .find('.open')
-      .updateCount();
+    .find('.selected')
+    .highlight()
+    .end()
+    .find('.open')
+    .updateCount();
 
   // bad
   const leds = stage.selectAll('.led').data(data).enter().append('svg:svg').class('led', true)
@@ -1669,15 +1669,15 @@ ESLint rules (applies this guide as linting rules):
 
   // good
   const leds = stage
-      .selectAll('.led')
-      .data(data)
-      .enter()
-      .append('svg:svg')
-      .classed('led', true)
-      .attr('width', (radius + margin) * 2)
-      .append('svg:g')
-      .attr('transform', 'translate(' + (radius + margin) + ',' + (radius + margin) + ')')
-      .call(tron.led);
+    .selectAll('.led')
+    .data(data)
+    .enter()
+    .append('svg:svg')
+    .classed('led', true)
+    .attr('width', (radius + margin) * 2)
+    .append('svg:g')
+    .attr('transform', 'translate(' + (radius + margin) + ',' + (radius + margin) + ')')
+    .call(tron.led);
   ```
 
   - [18.7](#18.7) <a name='18.7'></a> Leave a newline after blocks and before the next statement.


### PR DESCRIPTION
to align with rest of indentation standards

Solves #56 